### PR TITLE
Improvements to the message template to fit it on one line.

### DIFF
--- a/src/main/resources/templates/hipchat-message.ftl
+++ b/src/main/resources/templates/hipchat-message.ftl
@@ -1,4 +1,4 @@
-<p>Execution of job <#if executionData.context.job.execid?has_content>#${executionData.context.job.execid}/</#if>
+<p>Execution of job <#if executionData.context.job.execid?has_content>#${executionData.context.job.execid}</#if>
 <a href="${executionData.job.href}"><#if executionData.job.group?has_content>${executionData.job.group}/</#if>${executionData.job.name}</a>
 <#if trigger == "start">
 <b>started</b> by ${executionData.context.job.username}


### PR DESCRIPTION
Hey there,

I wonder if you'd consider merging this pull request for the default message format. I've modified the message template to keep it short and help it fit on a single line. In addition, it only shows the `executionData.context.job.username` when the job is being started.

Thanks!
Ryan
